### PR TITLE
배포 사이트 PageNotFound 에러 해결

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
## 개요
배포 사이트 접속 시 최상위 경로 이외의 경로 접속 시 발생하는 PageNotFound 에러를 해결하기위해 redirect 설정을 수행한다

## 작업내용
모든 경로에 대해 정상적으로 index.html를 전달할 수 있도록 redirect를 설정했다. 

## 참고
[Netlify 공식문서](https://docs.netlify.com/routing/redirects/rewrites-proxies/#history-pushstate-and-single-page-apps)

## 관련 이슈

- close #8 
